### PR TITLE
feat: Make Clickup metadata public, switch default integration to API KEY auth

### DIFF
--- a/apps/clickup/bundle/bots/load/clickup_folders_load/bot.ts
+++ b/apps/clickup/bundle/bots/load/clickup_folders_load/bot.ts
@@ -5,12 +5,6 @@ type FoldersResponse = {
 }
 
 export default function clickup_folders_load(bot: LoadBotApi) {
-	const spaceID = bot.getCredentials().defaultSpaceId
-	if (!spaceID) {
-		throw new Error(
-			"Default Clickup Space ID Config Value must be set. Please check your Site / Workspace settings."
-		)
-	}
 	const { conditions, collectionMetadata } = bot.loadRequest
 	// Build maps for quickly converting to/from Uesio/external field names
 	const uesioFieldsByExternalName = {
@@ -59,6 +53,27 @@ export default function clickup_folders_load(bot: LoadBotApi) {
 			},
 			{}
 		)
+
+	let spaceID = bot.getCredentials().defaultSpaceId
+
+	// See if there is a Condition that specifies a particular space id
+	if (conditions && conditions.length) {
+		const spaceIdCondition = conditions.find(
+			(condition) =>
+				condition.field === "space.id" &&
+				condition.operator === "EQ" &&
+				!!condition.value
+		)
+		if (spaceIdCondition) {
+			spaceID = spaceIdCondition.value as string
+		}
+	}
+
+	if (!spaceID) {
+		throw new Error(
+			"A valid space id is required, but no condition on space.id was provided, nor was a default Clickup Space ID Config Value found."
+		)
+	}
 
 	const url = `${bot
 		.getIntegration()

--- a/apps/clickup/bundle/bots/load/clickup_folders_load/bot.yaml
+++ b/apps/clickup/bundle/bots/load/clickup_folders_load/bot.yaml
@@ -1,3 +1,4 @@
 name: clickup_folders_load
+public: true
 type: LOAD
 dialect: TYPESCRIPT

--- a/apps/clickup/bundle/bots/load/clickup_tasks_load/bot.yaml
+++ b/apps/clickup/bundle/bots/load/clickup_tasks_load/bot.yaml
@@ -1,3 +1,4 @@
 name: clickup_tasks_load
+public: true
 type: LOAD
 dialect: TYPESCRIPT

--- a/apps/clickup/bundle/bots/save/clickup_folders_save/bot.yaml
+++ b/apps/clickup/bundle/bots/save/clickup_folders_save/bot.yaml
@@ -1,3 +1,4 @@
 name: clickup_folders_save
+public: true
 type: SAVE
 dialect: TYPESCRIPT

--- a/apps/clickup/bundle/collections/folder.yaml
+++ b/apps/clickup/bundle/collections/folder.yaml
@@ -1,4 +1,5 @@
 name: folder
+public: true
 type: EXTERNAL
 label: Folder
 pluralLabel: Folders

--- a/apps/clickup/bundle/collections/task.yaml
+++ b/apps/clickup/bundle/collections/task.yaml
@@ -1,4 +1,5 @@
 name: task
+public: true
 type: EXTERNAL
 label: Task
 pluralLabel: Tasks

--- a/apps/clickup/bundle/credentials/clickup_api_key.yaml
+++ b/apps/clickup/bundle/credentials/clickup_api_key.yaml
@@ -1,0 +1,11 @@
+name: clickup_api_key
+type: API_KEY
+apiKey:
+  key: clickup_api_key
+  location: header
+  locationName: Authorization
+  locationValue: ${apikey}
+entries:
+  defaultSpaceId:
+    type: configvalue
+    value: default_clickup_space_id

--- a/apps/clickup/bundle/fields/uesio/clickup/folder/archived.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/folder/archived.yaml
@@ -1,4 +1,5 @@
 name: archived
+public: true
 type: CHECKBOX
 label: Archived
 columnname: archived

--- a/apps/clickup/bundle/fields/uesio/clickup/folder/lists.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/folder/lists.yaml
@@ -1,4 +1,5 @@
 name: lists
+public: true
 type: LIST
 label: Lists
 subfields:

--- a/apps/clickup/bundle/fields/uesio/clickup/folder/name.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/folder/name.yaml
@@ -1,4 +1,5 @@
 name: name
+public: true
 type: TEXT
 label: Name
 columnname: name

--- a/apps/clickup/bundle/fields/uesio/clickup/folder/space.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/folder/space.yaml
@@ -1,0 +1,12 @@
+name: space
+public: true
+type: STRUCT
+label: Space
+subfields:
+  - name: id
+    label: Id
+    type: TEXT
+  - name: name
+    label: Name
+    type: TEXT
+columnname: space

--- a/apps/clickup/bundle/fields/uesio/clickup/folder/task_count.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/folder/task_count.yaml
@@ -1,4 +1,5 @@
 name: task_count
+public: true
 type: NUMBER
 label: Task Count
 columnname: task_count

--- a/apps/clickup/bundle/fields/uesio/clickup/task/assignees.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/assignees.yaml
@@ -1,4 +1,5 @@
 name: assignees
+public: true
 type: LIST
 label: Assignees
 subtype: TEXT

--- a/apps/clickup/bundle/fields/uesio/clickup/task/checklists.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/checklists.yaml
@@ -1,4 +1,5 @@
 name: checklists
+public: true
 type: LIST
 label: Checklist
 subtype: TEXT

--- a/apps/clickup/bundle/fields/uesio/clickup/task/custom_fields.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/custom_fields.yaml
@@ -1,4 +1,5 @@
 name: custom_fields
+public: true
 type: STRUCT
 label: List
 subfields:

--- a/apps/clickup/bundle/fields/uesio/clickup/task/date_closed.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/date_closed.yaml
@@ -1,4 +1,5 @@
 name: date_closed
+public: true
 type: TIMESTAMP
 label: Date Closed
 required: true

--- a/apps/clickup/bundle/fields/uesio/clickup/task/date_done.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/date_done.yaml
@@ -1,4 +1,5 @@
 name: date_done
+public: true
 type: TIMESTAMP
 label: Date Done
 columnname: date_done

--- a/apps/clickup/bundle/fields/uesio/clickup/task/due_date.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/due_date.yaml
@@ -1,4 +1,5 @@
 name: due_date
+public: true
 type: TIMESTAMP
 label: Due Date
 required: true

--- a/apps/clickup/bundle/fields/uesio/clickup/task/list.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/list.yaml
@@ -1,4 +1,5 @@
 name: list
+public: true
 type: STRUCT
 label: List
 subfields:

--- a/apps/clickup/bundle/fields/uesio/clickup/task/markdown_description.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/markdown_description.yaml
@@ -1,4 +1,5 @@
 name: markdown_description
+public: true
 type: LONGTEXT
 label: Markdown Description
 columnname: markdown_description

--- a/apps/clickup/bundle/fields/uesio/clickup/task/name.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/name.yaml
@@ -1,4 +1,5 @@
 name: name
+public: true
 type: TEXT
 label: Name
 required: true

--- a/apps/clickup/bundle/fields/uesio/clickup/task/orderindex.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/orderindex.yaml
@@ -1,4 +1,5 @@
 name: orderindex
+public: true
 type: NUMBER
 label: Order Index
 columnname: orderindex

--- a/apps/clickup/bundle/fields/uesio/clickup/task/priority.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/priority.yaml
@@ -1,4 +1,5 @@
 name: priority
+public: true
 type: TEXT
 label: Priority
 required: true

--- a/apps/clickup/bundle/fields/uesio/clickup/task/start_date.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/start_date.yaml
@@ -1,4 +1,5 @@
 name: start_date
+public: true
 type: TIMESTAMP
 label: Start Date
 required: true

--- a/apps/clickup/bundle/fields/uesio/clickup/task/status.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/status.yaml
@@ -1,4 +1,5 @@
 name: status
+public: true
 type: STRUCT
 label: Status
 subfields:

--- a/apps/clickup/bundle/fields/uesio/clickup/task/tags.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/tags.yaml
@@ -1,4 +1,5 @@
 name: tags
+public: true
 type: LIST
 label: Tags
 subtype: TEXT

--- a/apps/clickup/bundle/integrations/clickup.yaml
+++ b/apps/clickup/bundle/integrations/clickup.yaml
@@ -1,5 +1,5 @@
 name: clickup
 type: clickup
-authentication: OAUTH2_AUTHORIZATION_CODE
-credentials: clickup_oauth
+authentication: API_KEY
+credentials: clickup_api_key
 baseUrl: https://api.clickup.com/api/v2

--- a/apps/clickup/bundle/integrationtypes/clickup.yaml
+++ b/apps/clickup/bundle/integrationtypes/clickup.yaml
@@ -1,3 +1,2 @@
 name: clickup
-loadBot: clickup_load
-saveBot: clickup_save
+public: true

--- a/apps/clickup/bundle/secrets/clickup_api_key.yaml
+++ b/apps/clickup/bundle/secrets/clickup_api_key.yaml
@@ -1,4 +1,4 @@
-name: default_clickup_space_id
+name: clickup_api_key
 public: true
 store: platform
 managedBy: site

--- a/apps/clickup/generated/@types/@uesio/index.d.ts
+++ b/apps/clickup/generated/@types/@uesio/index.d.ts
@@ -18,10 +18,11 @@ type ConditionOperator =
 	| "GTE"
 	| "LTE"
 	| "IN"
+	| "NOT_IN"
 	| "IS_BLANK"
 	| "IS_NOT_BLANK"
 type FieldValue = string | number | boolean | object | null
-type ConditionType = "SEARCH" | "GROUP"
+type ConditionType = "SEARCH" | "GROUP" | "SUBQUERY"
 interface ConditionRequest {
 	field: string
 	operator: ConditionOperator
@@ -126,6 +127,11 @@ type RunIntegrationAction = (
 	options: unknown
 ) => unknown
 
+type CallBot = (
+	botName: string,
+	params: Record<string, FieldValue>
+) => Record<string, FieldValue>
+
 interface BeforeSaveBotApi {
 	addError: (error: string) => void
 	load: (loadRequest: LoadRequest) => WireRecord[]
@@ -144,6 +150,7 @@ interface AsAdminApi {
 	delete: (collectionName: string, records: WireRecord[]) => void
 	save: (collectionName: string, records: WireRecord[]) => void
 	runIntegrationAction: RunIntegrationAction
+	callBot: CallBot
 	getConfigValue: (configValueKey: string) => string
 }
 interface ListenerBotApi {
@@ -153,6 +160,7 @@ interface ListenerBotApi {
 	delete: (collectionName: string, records: WireRecord[]) => void
 	save: (collectionName: string, records: WireRecord[]) => void
 	runIntegrationAction: RunIntegrationAction
+	callBot: CallBot
 	getConfigValue: (configValueKey: string) => string
 	asAdmin: AsAdminApi
 	getSession: () => SessionApi
@@ -586,6 +594,7 @@ type ConditionOperators =
 	| "GTE"
 	| "LTE"
 	| "IN"
+	| "NOT_IN"
 	| "IS_BLANK"
 	| "IS_NOT_BLANK"
 type WireCondition =


### PR DESCRIPTION
# What does this PR do?

1. adds ability to configure the "space.id" Condition on a Clickup Folders load, to override the default space id
2. switches default Clickup integration to use API_KEY auth instead of OAuth per-user
3. makes all Clickup metadata public
