### PR TITLE
fix(clickup): Return custom fields in a Map

### DIFF
--- a/apps/clickup/bundle/fields/uesio/clickup/task/custom_fields.yaml
+++ b/apps/clickup/bundle/fields/uesio/clickup/task/custom_fields.yaml
@@ -1,7 +1,8 @@
 name: custom_fields
 public: true
-type: STRUCT
-label: List
+type: MAP
+subtype: STRUCT
+label: Custom Fields
 subfields:
   - name: id
     label: Field Id


### PR DESCRIPTION
# What does this PR do?

1. Converts custom fields to a MAP field of sub-type STRUCT, keyed by the custom field's UUID for stability
2. Adds support for querying on a particular Task field by id
