### PR TITLE
When there are no rows, don't crash everything

### DIFF
--- a/apps/smartsheet/bundle/bots/load/smartsheet_load/bot.ts
+++ b/apps/smartsheet/bundle/bots/load/smartsheet_load/bot.ts
@@ -17,7 +17,7 @@ type SheetRow = {
 
 type SheetResponse = {
 	columns: SheetColumn[]
-	rows: SheetRow[]
+	rows: SheetRow[] | undefined
 }
 
 export default function smartsheet_load(bot: LoadBotApi) {
@@ -76,7 +76,7 @@ export default function smartsheet_load(bot: LoadBotApi) {
 	const maxRecordForPagination = doPagination
 		? (queryParams.pageSize as number) - 1
 		: -1
-	body.rows.forEach((row, i) => {
+	body.rows?.forEach((row, i) => {
 		// If we are on the final row, do NOT add it to the bot's records,
 		// since we requested one more than we needed, but DO set has more records
 		// so that Uesio pagination controls will work
@@ -88,7 +88,7 @@ export default function smartsheet_load(bot: LoadBotApi) {
 			"uesio/core.id": row.id + "",
 		}
 
-		row.cells.forEach((cell) => {
+		row.cells?.forEach((cell) => {
 			const field = fields[cell.columnId]
 			if (field) {
 				record[field.namespace + "." + field.name] = cell.value

--- a/apps/smartsheet/tests/smartsheet_load.spec.ts
+++ b/apps/smartsheet/tests/smartsheet_load.spec.ts
@@ -4,7 +4,7 @@ import smartsheet_load from "../bundle/bots/load/smartsheet_load/bot"
 const sampleUesioCollectionName = "tasks"
 const sampleUesioNS = "luigi/foo"
 const mockBot = (
-	returnRecords: Record<string, FieldValue>[],
+	returnRecords?: Record<string, FieldValue>[],
 	loadRequest?: Partial<LoadRequestMetadata>
 ) => ({
 	loadRequest: {
@@ -90,6 +90,20 @@ describe("Smartsheet Load", () => {
 		smartsheet_load(bot as unknown as LoadBotApi)
 		expect(bot.addRecord).toHaveBeenCalledWith(uesioRow1)
 		expect(bot.addRecord).toHaveBeenCalledWith(uesioRow2)
+	})
+	it("should not bomb if no rows or cells are returned", () => {
+		let bot = mockBot(undefined)
+		smartsheet_load(bot as unknown as LoadBotApi)
+		expect(bot.addRecord).toHaveBeenCalledTimes(0)
+		bot = mockBot([
+			{
+				id: "123",
+			},
+		])
+		smartsheet_load(bot as unknown as LoadBotApi)
+		expect(bot.addRecord).toHaveBeenCalledWith({
+			"uesio/core.id": "123",
+		})
 	})
 	it("should only return specific rows from a sheet if uesio/core.id condition exists (multi-value)", () => {
 		const bot = mockBot([row1, row2], {


### PR DESCRIPTION
# What does this PR do?

Currently everything fails when the smartsheet loadbot is used y a page wire with `query: true`. I think we just don't want to return anything from the load and not give an error

```
Load Failed: TypeError: Cannot read property 'forEach' of undefined or null at smartsheet_load (load:uesio/smartsheet.smartsheet_load:44:8(147))
```

# Testing

If relevant, explain how to test the change locally
